### PR TITLE
Fix issue with socket.io connections failing.

### DIFF
--- a/src/simplisafe.js
+++ b/src/simplisafe.js
@@ -764,7 +764,8 @@ class SimpliSafe3 {
                     ns: `/v1/user/${userId}`,
                     accessToken: this.token
                 },
-                transports: ['websocket', 'polling']
+                transports: ['websocket', 'polling'],
+                pfx: []
             });
 
             // for debugging, we only want one of these listeners


### PR DESCRIPTION
socket.io sets pfx to null if it is undefined.  This now breaks the https code, which now checks explicitly against pfx === undefined.  Workaround is to set pfx to [].

https://github.com/nodejs/node/issues/36292