### PR TITLE
Add Self-Monitoring plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A complete (unofficial) [Homebridge](https://github.com/homebridge/homebridge) p
 </span>
 
 ## Requirements
-- **You must be signed up for a SimpliSafe monitoring plan that enables you to use the mobile app for this plugin to work.** The monitoring plan enables API access to SimpliSafe.
+- **You must be signed up for a SimpliSafe monitoring or self-monitoring plan that enables you to use the mobile app for this plugin to work.** The monitoring plan enables API access to SimpliSafe.
 - As of version 1.5.0 of this plugin, Homebridge v1.0.0 or greater is required. Because of [significant changes to Homebridge](https://github.com/homebridge/homebridge/releases/tag/1.0.0) the plugin may not work properly with older versions of Homebridge. The last version of this plugin to officially support Homebridge 0.4.53 was version 1.4.12 which can still be installed using a command like `sudo npm install -g --unsafe-perm homebridge-simplisafe3@1.4.12`.
 - Works with native Homebridge and [oznu/docker-homebridge](https://github.com/oznu/docker-homebridge)
 - Compatible with the official [Config UI X plugin](https://github.com/oznu/homebridge-config-ui-x) which is recommended for easiest usage

--- a/src/simplisafe.js
+++ b/src/simplisafe.js
@@ -444,7 +444,8 @@ class SimpliSafe3 {
             url: `/users/${userId}/subscriptions?activeOnly=false`
         });
 
-        let subscriptions = data.subscriptions.filter(s => s.sStatus === 10 || s.sStatus === 20);
+        // sStatus 7: Self-Monitoring with Camera Recording (5 cameras)
+        let subscriptions = data.subscriptions.filter(s => [7, 10, 20].includes(s.sStatus));
 
         if (this.accountNumber) {
             subscriptions = subscriptions.filter(s => s.location.account === this.accountNumber);


### PR DESCRIPTION
I have been using this plugin for a few days with the `Interactive Monitoring` plan from SimpliSafe but discovered it was not working anymore when downgrading to `Self-Monitoring with Camera Recording`, even though I had the same access from the SimpliSafe mobile app.

After some debugging, I found out that the `sStatus` for my plan was `7` and was filtered out from the possible subscriptions.

I tested it, and it's now working great! 

Subscriptions might have changed recently, and this plugin might also work with other new [plans](https://support.simplisafe.com/hc/en-us/articles/360023809972-What-are-the-service-plan-options-)/`sStatus` from SimpliSafe, but I wasn't able to try it out.