### PR TITLE
Update index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -446,7 +446,7 @@ class SS3Platform {
                         if (addAndRemove) {
                             let newAccessory = new Accessory(cameraName, uuid);
                             newAccessory.addService(Service.MotionSensor);
-                            if (camera.model == 'SS002') { // SSO02 is doorbell cam
+                            if (camera.supportedFeatures.doorbell) {
                                 newAccessory.addService(Service.Doorbell);
                             }
                             cameraAccessory.setAccessory(newAccessory);


### PR DESCRIPTION
Change how doorbells are identified from using the model number to using the doorbell key in the supportedFeatures object of the camera. This should allow future doorbells that SimpliSafe releases to be detected as doorbells without the need to wait for an update to this.