### PR TITLE
Feature: support excluding cameras

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -344,6 +344,11 @@ class SS3Platform {
                         this.log(`Discovered camera '${cameraName}' from SimpliSafe:`, JSON.stringify(camera));
                     }
 
+                    if (camera.serial && this.excludedDevices.includes(camera.serial)) {
+                        this.log.info(`Excluding camera with serial '${camera.serial}'`);
+                        continue;
+                    }
+
                     let cameraAccessory = this.accessories.find(acc => acc.UUID === uuid);
                     if (!cameraAccessory) {
                         const cameraAccessory = new Camera(


### PR DESCRIPTION
Please allow excluding of cameras (based on uuid rather than serial no since they don't seem to have a serial no here) the same way we can exclude other devices.