### PR TITLE
Fix slow stream startup: skip cloud AAC transcode, cap ffmpeg probe, cache snapshots

### DIFF
--- a/src/lib/streamingDelegate.js
+++ b/src/lib/streamingDelegate.js
@@ -16,6 +16,17 @@ const privacyShutterImageInBytes = fs.readFileSync(privacyShutterImage);
 const unsupportedCameraImage = path.resolve(__dirname, '..', 'images', 'unsupportedcamera_snapshot.png');
 const unsupportedCameraImageInBytes = fs.readFileSync(unsupportedCameraImage);
 
+// HomeKit fetches a snapshot for every visible camera tile before it will open a live
+// stream, and it processes requests on a HAP connection strictly one at a time — so each
+// slow mjpg fetch (~3-5s on an idle camera) queues the live-stream request behind it.
+// Cache the most recent snapshot per (camera, width) briefly and serve it instantly,
+// refreshing in the background, so tile requests can't delay the live view.
+// Motion-triggered snapshots always fetch fresh; nothing older than the max-age is served.
+const snapshotCache = {};
+const snapshotInflight = {};
+const SNAPSHOT_SERVE_MAX_AGE = 60 * 1000; // ms; upper bound on served snapshot age
+const SNAPSHOT_REFRESH_AFTER = 15 * 1000; // ms; background-refresh a served snapshot older than this
+
 class StreamingDelegate {
     constructor(ss3Camera) {
         this.ss3Camera = ss3Camera;
@@ -113,6 +124,35 @@ class StreamingDelegate {
             }
         }
 
+        const cacheKey = `${this.ss3Camera.cameraDetails.uuid}:${request.width}`;
+        const cached = snapshotCache[cacheKey];
+        if (!this.ss3Camera.motionIsTriggered && cached && (Date.now() - cached.time) < SNAPSHOT_SERVE_MAX_AGE) {
+            const age = Date.now() - cached.time;
+            if (this.ss3Camera.debug) this.log(`Served cached snapshot for '${this.cameraDetails.cameraSettings.cameraName}' (${request.width}px, ${Math.round(age / 1000)}s old)`);
+            callback(undefined, cached.img);
+            // Refresh in the background (coalesced, does its own DNS) so the tile stays current.
+            if (age > SNAPSHOT_REFRESH_AFTER && !snapshotInflight[cacheKey]) {
+                const refresh = (async () => {
+                    try {
+                        let newIpAddress = await dnsLookup('media.simplisafe.com');
+                        this.serverIpAddress = newIpAddress.address;
+                    } catch (err) { /* keep last known IP */ }
+                    const img = await jpegExtract({
+                        url: `https://${this.serverIpAddress}/v1/${this.ss3Camera.cameraDetails.uuid}/mjpg?x=${request.width}&fr=1`,
+                        headers: {
+                            'Authorization': `Bearer ${this.ss3Camera.authManager.accessToken}`
+                        },
+                        rejectUnauthorized: false
+                    });
+                    snapshotCache[cacheKey] = { img: img, time: Date.now() };
+                    return img;
+                })();
+                snapshotInflight[cacheKey] = refresh;
+                refresh.catch(() => {}).then(() => { delete snapshotInflight[cacheKey]; });
+            }
+            return;
+        }
+
         try {
             let newIpAddress = await dnsLookup('media.simplisafe.com');
             this.serverIpAddress = newIpAddress.address;
@@ -130,11 +170,21 @@ class StreamingDelegate {
             rejectUnauthorized: false // OK because we are using IP and just polled DNS
         };
 
-        jpegExtract(url).then(img => {
+        // Coalesce concurrent fetches for the same (camera, width).
+        let fetch = snapshotInflight[cacheKey];
+        if (!fetch) {
+            fetch = jpegExtract(url).then(img => {
+                snapshotCache[cacheKey] = { img: img, time: Date.now() };
+                return img;
+            });
+            snapshotInflight[cacheKey] = fetch;
+            fetch.catch(() => {}).then(() => { delete snapshotInflight[cacheKey]; });
+        }
+        fetch.then(img => {
             if (this.ss3Camera.debug) this.log(`Closed '${this.cameraDetails.cameraSettings.cameraName}' snapshot request with ${Math.round(img.length/1000)}kB image`);
             callback(undefined, img);
         }).catch(err => {
-            this.log.error('An error occurred while making snapshot request:', err.statusCode ? err.statusCode : '', err.statusMessage ? err.statusMessage : '');
+            this.log.error(`An error occurred while making snapshot request for '${this.cameraDetails.cameraSettings.cameraName}':`, err.statusCode || err.statusMessage || err.message || err);
             if (this.ss3Camera.debug) this.log.error(err);
             callback(err);
         });

--- a/src/lib/streamingDelegate.js
+++ b/src/lib/streamingDelegate.js
@@ -317,8 +317,14 @@ class StreamingDelegate {
                     // every stream start (measured cold first-byte ~5.0s with the param vs ~1.9s
                     // without; the native app does not request it). The camera's native audio
                     // (speex) is decoded by ffmpeg locally and re-encoded to AAC-ELD/OPUS below.
+                    // -analyzeduration 1s: ffmpeg's default probe reads ~5s of the live stream
+                    // before opening the input, but the source is decodable immediately (it
+                    // begins with SPS/PPS and a keyframe). Measured first encoded frame:
+                    // ~6.6s -> ~3s. Output audio params come from the encoder config, so the
+                    // shorter probe is safe.
                     let sourceArgs = [
                         ['-re'],
+                        ['-analyzeduration', 1000000],
                         ['-headers', `Authorization: Bearer ${this.ss3Camera.authManager.accessToken}`],
                         ['-i', `https://${this.serverIpAddress}/v1/${this.ss3Camera.cameraDetails.uuid}/flv?x=${width}`]
                     ];

--- a/src/lib/streamingDelegate.js
+++ b/src/lib/streamingDelegate.js
@@ -312,10 +312,15 @@ class StreamingDelegate {
                         }
                     }
 
+                    // Do not request audioEncoding=AAC: it makes SimpliSafe's cloud provision a
+                    // server-side audio transcoder before it sends the first byte, adding ~3s to
+                    // every stream start (measured cold first-byte ~5.0s with the param vs ~1.9s
+                    // without; the native app does not request it). The camera's native audio
+                    // (speex) is decoded by ffmpeg locally and re-encoded to AAC-ELD/OPUS below.
                     let sourceArgs = [
                         ['-re'],
                         ['-headers', `Authorization: Bearer ${this.ss3Camera.authManager.accessToken}`],
-                        ['-i', `https://${this.serverIpAddress}/v1/${this.ss3Camera.cameraDetails.uuid}/flv?x=${width}&audioEncoding=AAC`]
+                        ['-i', `https://${this.serverIpAddress}/v1/${this.ss3Camera.cameraDetails.uuid}/flv?x=${width}`]
                     ];
 
                     let videoArgs = [
@@ -364,8 +369,6 @@ class StreamingDelegate {
 
                     if (request.audio && request.audio.codec == 'OPUS') {
                         // Request is for OPUS codec, serve that
-                        let iArg = sourceArgs.find(arg => arg[0] == '-i');
-                        iArg[1] = iArg[1].replace('&audioEncoding=AAC', '');
                         let aCodecArg = audioArgs.find(arg => arg[0] == '-acodec');
                         aCodecArg[1] = 'libopus';
                         let profileArg = audioArgs.find(arg => arg[0] == '-profile:a');


### PR DESCRIPTION
HomeKit live view was consistently 3–5s slower than the native SimpliSafe app. Profiled on a Pi 5 with SS003 cameras; three small fixes (+64/−5, one file):

1. **Don't request `audioEncoding=AAC`** — this flv URL param makes SimpliSafe's cloud provision a server-side audio transcoder before it sends the first byte. The native app doesn't request it. ffmpeg decodes the camera's native speex audio locally and still outputs AAC-ELD/OPUS — nothing changes for HomeKit; audio verified working.

2. **`-analyzeduration 1000000`** — the stream is decodable immediately (starts with SPS/PPS + keyframe), but ffmpeg's default probe reads ~5s of live stream before opening the input. Output audio params come from the encoder config, so the short probe is safe.

3. **Snapshot cache** (reworked per review): served per **(camera, width)** only if **<60s old**, background-refreshed after 15s, concurrent fetches coalesced, **motion-triggered snapshots always fetch fresh**.

## Impact per change

| Fix | Removes | Measured impact |
|---|---|---|
| Snapshot cache | Serialized tile fetches queued ahead of the stream (HAP handles one request per connection at a time; ~4–5s per visible camera) | **−4 to −14s** on multi-camera views; ~0 when tiles are warm |
| Drop `audioEncoding=AAC` | Cloud audio-transcoder setup before the first byte | First byte **4.8–5.3s → 1.4–2.5s** |
| `-analyzeduration 1s` | ffmpeg's ~5s live-stream probe | Realizes the row above — the old transcoded stream arrived as a burst that hid the probe cost; **together −2 to −2.5s on every open** |

The last two work as a pair (dropping AAC alone exposes the probe cost and would regress; the probe cap alone changes nothing).

End-to-end tap → first encoded frame: **~5–6s → ~2.3–3s** (and the ~15s cold-tile worst case eliminated).